### PR TITLE
Fix determinism - closes #26

### DIFF
--- a/codes/surrogates/DeepONet/deeponet.py
+++ b/codes/surrogates/DeepONet/deeponet.py
@@ -6,13 +6,13 @@ import torch
 import torch.nn as nn
 from schedulefree import AdamWScheduleFree
 from torch.profiler import ProfilerActivity, profile, record_function
-from torch.utils.data import DataLoader, Dataset, TensorDataset
+from torch.utils.data import DataLoader, TensorDataset
 
 from codes.surrogates.AbstractSurrogate.surrogates import AbstractSurrogateModel
 from codes.utils import time_execution, worker_init_fn
 
 from .deeponet_config import MultiONetBaseConfig
-from .don_utils import mass_conservation_loss
+from .don_utils import PreBatchedDataset, mass_conservation_loss
 
 
 class BranchNet(nn.Module):
@@ -139,30 +139,6 @@ class OperatorNetwork(AbstractSurrogateModel):
 
 
 OperatorNetworkType = TypeVar("OperatorNetworkType", bound=OperatorNetwork)
-
-
-class PreBatchedDataset(Dataset):
-    """
-    Dataset for pre-batched data.
-
-    Args:
-        branch_inputs (list[Tensor]): List of precomputed branch input batches.
-        trunk_inputs (list[Tensor]): List of precomputed trunk input batches.
-        targets (list[Tensor]): List of precomputed target batches.
-    """
-
-    def __init__(self, branch_inputs, trunk_inputs, targets):
-        self.branch_inputs = branch_inputs
-        self.trunk_inputs = trunk_inputs
-        self.targets = targets
-
-    def __getitem__(self, index):
-        # Return the precomputed batch at the given index
-        return self.branch_inputs[index], self.trunk_inputs[index], self.targets[index]
-
-    def __len__(self):
-        # Return the number of precomputed batches
-        return len(self.branch_inputs)
 
 
 class MultiONet(OperatorNetwork):
@@ -586,7 +562,7 @@ class MultiONet(OperatorNetwork):
         return DataLoader(
             dataset,
             batch_size=1,  # Each "batch" is now a precomputed batch
-            shuffle=shuffle,  # The DataLoader will shuffle the order of the precomputed batches
+            shuffle=False,  # Shuffling is handled by the precomputed batches
             num_workers=0,
             collate_fn=custom_collate_fn,
             worker_init_fn=worker_init_fn,

--- a/codes/surrogates/DeepONet/don_utils.py
+++ b/codes/surrogates/DeepONet/don_utils.py
@@ -3,12 +3,37 @@ from __future__ import annotations
 import os
 import time
 from datetime import datetime
+
+import torch
 import yaml
 from torch import nn
-import torch
-
+from torch.utils.data import Dataset
 
 # TODO complete type hints
+
+
+class PreBatchedDataset(Dataset):
+    """
+    Dataset for pre-batched data.
+
+    Args:
+        branch_inputs (list[Tensor]): List of precomputed branch input batches.
+        trunk_inputs (list[Tensor]): List of precomputed trunk input batches.
+        targets (list[Tensor]): List of precomputed target batches.
+    """
+
+    def __init__(self, branch_inputs, trunk_inputs, targets):
+        self.branch_inputs = branch_inputs
+        self.trunk_inputs = trunk_inputs
+        self.targets = targets
+
+    def __getitem__(self, index):
+        # Return the precomputed batch at the given index
+        return self.branch_inputs[index], self.trunk_inputs[index], self.targets[index]
+
+    def __len__(self):
+        # Return the number of precomputed batches
+        return len(self.branch_inputs)
 
 
 def read_yaml_config(model_path):

--- a/codes/surrogates/LatentNeuralODE/latent_neural_ode.py
+++ b/codes/surrogates/LatentNeuralODE/latent_neural_ode.py
@@ -84,7 +84,7 @@ class LatentNeuralODE(AbstractSurrogateModel):
         shuffle: bool = True,
     ) -> tuple[DataLoader, DataLoader | None, DataLoader | None]:
         """
-        Prepares the data for training by creating a DataLoader object.
+        Prepares the data for training by creating DataLoader objects.
 
         Args:
             dataset_train (np.ndarray): The training dataset.
@@ -92,39 +92,49 @@ class LatentNeuralODE(AbstractSurrogateModel):
             dataset_val (np.ndarray): The validation dataset.
             timesteps (np.ndarray): The array of timesteps.
             batch_size (int): The batch size for the DataLoader.
-            shuffle (bool): Whether to shuffle the data.
+            shuffle (bool): Whether to shuffle the training data.
 
         Returns:
-            DataLoader: The DataLoader object containing the prepared data.
+            tuple[DataLoader, DataLoader | None, DataLoader | None]:
+                - DataLoader for training data.
+                - DataLoader for test data (None if no test data provided).
+                - DataLoader for validation data (None if no validation data provided).
         """
+        # Shuffle training data if required
+        if shuffle:
+            shuffled_indices = np.random.permutation(len(dataset_train))
+            dataset_train = dataset_train[shuffled_indices]
 
+        # Create training DataLoader
         dset_train = ChemDataset(dataset_train, timesteps, device=self.device)
         dataloader_train = DataLoader(
             dset_train,
             batch_size=batch_size,
-            shuffle=shuffle,
+            shuffle=False,  # Shuffle already handled manually above
             worker_init_fn=worker_init_fn,
             collate_fn=lambda x: (x[0], x[1]),
         )
 
+        # Create test DataLoader (no shuffling)
         dataloader_test = None
         if dataset_test is not None:
             dset_test = ChemDataset(dataset_test, timesteps, device=self.device)
             dataloader_test = DataLoader(
                 dset_test,
                 batch_size=batch_size,
-                shuffle=shuffle,
+                shuffle=False,
                 worker_init_fn=worker_init_fn,
                 collate_fn=lambda x: (x[0], x[1]),
             )
 
+        # Create validation DataLoader (no shuffling)
         dataloader_val = None
         if dataset_val is not None:
             dset_val = ChemDataset(dataset_val, timesteps, device=self.device)
             dataloader_val = DataLoader(
                 dset_val,
                 batch_size=batch_size,
-                shuffle=shuffle,
+                shuffle=False,
                 worker_init_fn=worker_init_fn,
                 collate_fn=lambda x: (x[0], x[1]),
             )

--- a/codes/surrogates/LatentPolynomial/latent_poly.py
+++ b/codes/surrogates/LatentPolynomial/latent_poly.py
@@ -76,45 +76,59 @@ class LatentPoly(AbstractSurrogateModel):
         shuffle: bool = True,
     ) -> tuple[DataLoader, DataLoader | None, DataLoader | None]:
         """
-        Prepares the data for training by creating a DataLoader object.
+        Prepares the data for training by creating DataLoader objects.
 
         Args:
-            dataset (np.ndarray): The input dataset.
-            timesteps (np.ndarray): The timesteps for the dataset.
-            batch_size (int | None): The batch size for the DataLoader. If None, the entire dataset is loaded as a single batch.
-            shuffle (bool): Whether to shuffle the data during training.
+            dataset_train (np.ndarray): The training dataset.
+            dataset_test (np.ndarray): The test dataset.
+            dataset_val (np.ndarray): The validation dataset.
+            timesteps (np.ndarray): The array of timesteps.
+            batch_size (int): The batch size for the DataLoader.
+            shuffle (bool): Whether to shuffle the training data.
 
         Returns:
-            DataLoader: The DataLoader object containing the prepared data.
+            tuple[DataLoader, DataLoader | None, DataLoader | None]:
+                - DataLoader for training data.
+                - DataLoader for test data (None if no test data provided).
+                - DataLoader for validation data (None if no validation data provided).
         """
+        # Shuffle training data if required
+        if shuffle:
+            shuffled_indices = np.random.permutation(len(dataset_train))
+            dataset_train = dataset_train[shuffled_indices]
 
+        # Create training DataLoader
         dset_train = ChemDataset(dataset_train, timesteps, device=self.device)
         dataloader_train = DataLoader(
             dset_train,
             batch_size=batch_size,
-            shuffle=shuffle,
+            shuffle=False,  # Shuffle already handled manually above
+            worker_init_fn=worker_init_fn,
             collate_fn=lambda x: (x[0], x[1]),
         )
 
+        # Create test DataLoader (no shuffling)
         dataloader_test = None
         if dataset_test is not None:
             dset_test = ChemDataset(dataset_test, timesteps, device=self.device)
             dataloader_test = DataLoader(
                 dset_test,
                 batch_size=batch_size,
-                shuffle=shuffle,
+                shuffle=False,
+                worker_init_fn=worker_init_fn,
                 collate_fn=lambda x: (x[0], x[1]),
             )
 
+        # Create validation DataLoader (no shuffling)
         dataloader_val = None
         if dataset_val is not None:
             dset_val = ChemDataset(dataset_val, timesteps, device=self.device)
             dataloader_val = DataLoader(
                 dset_val,
                 batch_size=batch_size,
-                shuffle=shuffle,
-                collate_fn=lambda x: (x[0], x[1]),
+                shuffle=False,
                 worker_init_fn=worker_init_fn,
+                collate_fn=lambda x: (x[0], x[1]),
             )
 
         return dataloader_train, dataloader_test, dataloader_val

--- a/codes/train/train_fcts.py
+++ b/codes/train/train_fcts.py
@@ -1,4 +1,5 @@
 import os
+import threading
 from queue import Queue
 from threading import Thread
 
@@ -7,6 +8,7 @@ from tqdm import tqdm
 from codes.benchmark.bench_utils import get_model_config, get_surrogate
 from codes.utils import (
     check_and_load_data,
+    determine_batch_size,
     get_data_subset,
     get_progress_bar,
     load_and_save_config,
@@ -15,6 +17,20 @@ from codes.utils import (
     save_task_list,
     set_random_seeds,
 )
+
+
+class DummyLock:
+    def acquire(self):
+        pass
+
+    def release(self):
+        pass
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
 
 
 def train_and_save_model(
@@ -26,10 +42,13 @@ def train_and_save_model(
     epochs: int | None = None,
     device: str = "cpu",
     position: int = 1,
+    threadlock: threading.Lock = DummyLock(),
 ):
     """
     Train and save a model for a specific benchmark mode. The parameters are determined
     by the task(s) which is created from the config file.
+    Threadlock is used to make the training deterministic. In the single-threaded case,
+    uses a dummy lock instead.
 
     Args:
         surr_name (str): The name of the surrogate model.
@@ -40,6 +59,7 @@ def train_and_save_model(
         epochs (int, optional): The number of epochs for the training. Defaults to None.
         device (str, optional): The device for the training. Defaults to "cpu".
         position (int, optional): The position of the model in the task list. Defaults to 1.
+        threadlock (threading.Lock, optional): A lock to prevent threading issues with PyTorch. Defaults to None.
     """
     config_path = f"trained/{training_id}/config.yaml"
     config = load_and_save_config(config_path, save=False)
@@ -59,37 +79,31 @@ def train_and_save_model(
         full_train_data, full_test_data, timesteps, mode, metric
     )
 
-    n_timesteps = train_data.shape[1]
-    n_chemicals = train_data.shape[2]
+    _, n_timesteps, n_chemicals = train_data.shape
 
     # Get the surrogate class
     surrogate_class = get_surrogate(surr_name)
     model_config = get_model_config(surr_name, config)
-    model = surrogate_class(device, n_chemicals, n_timesteps, model_config)
+
+    # Apply threadlock to avoid issues with PyTorch
+    with threadlock:
+        set_random_seeds(seed, device)
+        model = surrogate_class(device, n_chemicals, n_timesteps, model_config)
     model.normalisation = data_params
     surr_idx = config["surrogates"].index(surr_name)
 
-    # Determine the batch size
-    if isinstance(config["batch_size"], list):
-        if len(config["batch_size"]) != len(config["surrogates"]):
-            raise ValueError(
-                "The number of provided batch sizes must match the number of surrogate models."
-            )
-        else:
-            batch_size = config["batch_size"][surr_idx]
-    else:
-        batch_size = config["batch_size"]
-    batch_size = metric if mode == "batch_size" else batch_size
-    # epochs = epochs if epochs is not None else config["epochs"]
+    batch_size = determine_batch_size(config, surr_idx, mode, metric)
 
-    train_loader, test_loader, _ = model.prepare_data(
-        dataset_train=train_data,
-        dataset_test=test_data,
-        dataset_val=None,
-        timesteps=timesteps,
-        batch_size=batch_size,
-        shuffle=True,
-    )
+    with threadlock:
+        set_random_seeds(seed, device)
+        train_loader, test_loader, _ = model.prepare_data(
+            dataset_train=train_data,
+            dataset_test=test_data,
+            dataset_val=None,
+            timesteps=timesteps,
+            batch_size=batch_size,
+            shuffle=True,
+        )
 
     description = make_description(mode, device, str(metric), surr_name)
 
@@ -171,6 +185,7 @@ def worker(
     overall_progress_bar: tqdm,
     task_list_filepath: str,
     errors_encountered: list[bool],
+    threadlock: threading.Lock,
 ):
     """
     Worker function to process tasks from the task queue on the given device.
@@ -183,35 +198,26 @@ def worker(
         task_list_filepath (str): The filepath to the JSON task list.
         errors_encountered (list[bool]): A shared mutable flag array indicating if an error has occurred
                                          (True if at least one task failed).
+        threadlock (threading.Lock): A lock to prevent threading issues with PyTorch.
     """
     while not task_queue.empty():
         try:
             task = task_queue.get_nowait()  # Remove the task from the in-memory queue
-            # Set the seed for the training
-            seed = task[4]
-            set_random_seeds(seed, device)
-            train_and_save_model(*task, device=device, position=device_idx + 1)
+            train_and_save_model(
+                *task, device=device, position=device_idx + 1, threadlock=threadlock
+            )
 
             # Mark that we have successfully processed this task
             task_queue.task_done()
             overall_progress_bar.update(1)
-
-            # Only remove *this* successful task from the JSON
             current_list = load_task_list(task_list_filepath)
-
-            # Convert the task tuple to a list if you are storing tasks as lists in JSON
-            # (Because json.dump(...) typically stores lists, not tuples.)
-            # Example: if 'task' is a tuple, do this:
             task_as_list = list(task)
 
-            # Now remove the just-finished task from the JSON list
             try:
                 current_list.remove(task_as_list)
             except ValueError:
-                # In case it's already gone or doesn't match exactly
                 pass
 
-            # Re-save the updated list
             save_task_list(current_list, task_list_filepath)
 
         except Exception as e:
@@ -222,8 +228,6 @@ def worker(
 
             # Flag that at least one task has failed
             errors_encountered[0] = True
-            # Crucially, we do *not* remove the task from JSON here
-            # so that it remains for a future run.
 
 
 def parallel_training(tasks, device_list, task_list_filepath: str):
@@ -235,6 +239,7 @@ def parallel_training(tasks, device_list, task_list_filepath: str):
     overall_progress_bar = get_progress_bar(tasks)
 
     threads = []
+    threadlock = threading.Lock()
     for i, device in enumerate(device_list):
         thread = Thread(
             target=worker,
@@ -245,6 +250,7 @@ def parallel_training(tasks, device_list, task_list_filepath: str):
                 overall_progress_bar,
                 task_list_filepath,
                 errors_encountered,
+                threadlock,
             ),
         )
         thread.start()
@@ -281,8 +287,6 @@ def sequential_training(tasks, device_list, task_list_filepath: str):
 
     for task in tasks:
         try:
-            seed = task[4]
-            set_random_seeds(seed, device)
             train_and_save_model(*task, device=device)
             overall_progress_bar.update(1)
 

--- a/codes/utils/__init__.py
+++ b/codes/utils/__init__.py
@@ -19,6 +19,7 @@ from .utils import (
     set_random_seeds,
     time_execution,
     worker_init_fn,
+    determine_batch_size,
 )
 
 __all__ = [
@@ -40,4 +41,5 @@ __all__ = [
     "save_task_list",
     "load_task_list",
     "check_training_status",
+    "determine_batch_size",
 ]

--- a/codes/utils/utils.py
+++ b/codes/utils/utils.py
@@ -304,3 +304,32 @@ def check_training_status(config: dict) -> tuple[str, bool]:
             copy_config = True
 
     return task_list_filepath, copy_config
+
+
+def determine_batch_size(config, surr_idx, mode, metric):
+    """
+    Determine the appropriate batch size based on the config, surrogate index, mode, and metric.
+
+    Args:
+        config (dict): The configuration dictionary.
+        surr_idx (int): Index of the surrogate model in the config.
+        mode (str): The benchmark mode (e.g., "main", "batch_size").
+        metric (int): Metric used for determining the batch size in "batch_size" mode.
+
+    Returns:
+        int: The determined batch size.
+
+    Raises:
+        ValueError: If the number of batch sizes does not match the number of surrogates.
+    """
+    batch_size_config = config["batch_size"]
+    if isinstance(batch_size_config, list):
+        if len(batch_size_config) != len(config["surrogates"]):
+            raise ValueError(
+                "The number of provided batch sizes must match the number of surrogate models."
+            )
+        batch_size = batch_size_config[surr_idx]
+    else:
+        batch_size = batch_size_config
+
+    return metric if mode == "batch_size" else batch_size

--- a/config.yaml
+++ b/config.yaml
@@ -1,15 +1,15 @@
 # Global settings for the benchmark
-training_id: "osu2008_determinism_5"
+training_id: "osu2008_losstest"
 surrogates: ["MultiONet", "FullyConnected", "LatentPoly", "LatentNeuralODE"]
 batch_size: [4096, 4096, 512, 512]
-epochs: [10, 10, 10, 10]
+epochs: [2000, 2000, 2000, 2000]
 dataset: 
   name: "osu2008"
   log10_transform: True
   normalise: "minmax" # "minmax" # "standardise", "minmax", "disable"
   use_optimal_params: True
   tolerance: 1e-30
-devices: ["cuda:0"] # ["cuda:0", "cuda:1", "cuda:2", "cuda:3"]
+devices: ["cuda:2", "cuda:3", "cuda:4", "cuda:5"] # ["cuda:4"]
 seed: 42
 verbose: False
 
@@ -32,9 +32,9 @@ uncertainty:
 
 # Evaluations during benchmark
 losses: True
-gradients: True
-timing: True
-compute: True
+gradients: False
+timing: False
+compute: False
 compare: True # Whether to compare the surrogates
 
 

--- a/run_training.py
+++ b/run_training.py
@@ -1,5 +1,8 @@
+import os
 from argparse import ArgumentParser
 from datetime import timedelta
+
+os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
 
 import torch
 from tqdm import tqdm


### PR DESCRIPTION
Added thread locks with seeding at the critical points where randomness is used - during model initialisation and dataset shuffling. Also adjusted the DataLoader shuffle settings such that only the training data is shuffled, and the shuffling occurs only before the training begins. This means that the batch order and the sample order inside each batch are the same across training, but the dataset is at least shuffled once before making the batches.